### PR TITLE
Upgrade Project, Fix build in new MSVC versions (snprinft)

### DIFF
--- a/psarc/file.cpp
+++ b/psarc/file.cpp
@@ -5,10 +5,6 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#if _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #include "file.h"
 
 struct File_impl {
@@ -164,5 +160,3 @@ uint32_t File::readUint32BE(uint8_t *ptr) {
 void File::write(void *ptr, uint32_t size) {
 	_impl->write(ptr, size);
 }
-
-#undef snprintf

--- a/psarc/psarc.cpp
+++ b/psarc/psarc.cpp
@@ -5,10 +5,6 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#if _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #include "psarc.h"
 #include "strndup.h"
 
@@ -265,5 +261,3 @@ void PSARC::read(const char *arcName, uint32_t start, uint32_t end) {
 void PSARC::readHeader(const char *arcName) {
 	read(arcName, 0, 0, true);
 }
-
-#undef snprintf

--- a/psarc/psarc.vcxproj
+++ b/psarc/psarc.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -13,18 +13,19 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2F36903F-A7FB-4F90-9A54-482E2D81407B}</ProjectGuid>
     <RootNamespace>psarc</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/psarc/zconf.h
+++ b/psarc/zconf.h
@@ -404,10 +404,6 @@ typedef uLong FAR uLongf;
 #  define NO_vsnprintf
 #endif
 
-#if defined(__MVS__)
-#  define NO_vsnprintf
-#endif
-
 /* MVS linker does not support external names larger than 8 bytes */
 #if defined(__MVS__)
   #pragma map(deflateInit_,"DEIN")


### PR DESCRIPTION
MSVC now supports `snprintf ` and `#define snprintf _snprintf` breaks compilations
Also upgraded the project