### PR TITLE
Add a Github Actions workflow

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,39 @@
+name: MSBuild
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  SOLUTION_FILE_PATH: .
+  BUILD_CONFIGURATION: Release
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload package
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: psarc-tool
+        path: bin
+        retention-days: 64


### PR DESCRIPTION
Found this project while trying to rip data from _PlayStation All-Stars Battle Royale_ and was kinda annoyed that it had no releases of any kind (I *really* didn't wanna go through the hassle of setting up VS just to build one single tool), so I threw together a quick and dirty Github Actions workflow. 

This file will auto-build the tool every time a new commit's made (including the merging of this commit). It doesn't create a Github release though, you'll have to do that manually still. Haven't tested the resulting executables but I have reason to believe they work fine compiled this way.